### PR TITLE
DEVSOL-1390: Fatal error in Apigee\Mint\DeveloperRatePlan.php on line 22...

### DIFF
--- a/Apigee/Mint/DeveloperRatePlan.php
+++ b/Apigee/Mint/DeveloperRatePlan.php
@@ -218,8 +218,8 @@ class DeveloperRatePlan extends Base\BaseObject
     {
         $obj = array(
             'developer' => array('id' => $this->dev),
-            'endDate' => $this->getEndDateTime()->format('Y-m-d H:i:s'),
-            'startDate' => $this->getStartDateTime()->format('Y-m-d H:i:s'),
+            'endDate' => $this->getEndDateTime() instanceof DateTime ? $this->getEndDateTime()->format('Y-m-d H:i:s') : '',
+            'startDate' => $this->getStartDateTime() instanceof DateTime ? $this->getStartDateTime()->format('Y-m-d H:i:s') : '',
             'id' => $this->id,
             'ratePlan' => null
         );


### PR DESCRIPTION
Hi @cnovak ,

I made this change so that there is no fatal error when the __toString() method is called and if the start date or the end date is empty.

Regards,
Sudheesh
