### PR TITLE
DEVSOL-1397: If PUT of template fails with a 404, try POST instead.

### DIFF
--- a/Apigee/SmartDocs/Template.php
+++ b/Apigee/SmartDocs/Template.php
@@ -20,7 +20,9 @@ class Template extends APIObject
      * Initializes this object's base URL.
      *
      * @param \Apigee\Util\OrgConfig $config
+     *   Object containing org configuration settings.
      * @param string $modelId
+     *   UUID or machine-name of the model.
      */
     public function __construct(OrgConfig $config, $modelId)
     {
@@ -31,8 +33,13 @@ class Template extends APIObject
      * Loads a template of a given name and type.
      *
      * @param string $name
+     *   Name of the template.
      * @param string $type
+     *   Either 'index' or 'method'.
+     *
      * @return string
+     *   Returns the template HTML.
+     *
      * @throws ParameterException
      */
     public function load($name, $type)
@@ -47,11 +54,22 @@ class Template extends APIObject
     /**
      * Saves HTML to a template of a given name and type.
      *
+     * If $update is true and the call results in a 404, we set $update to
+     * false and re-try, since this indicates that the template did not exist
+     * yet.
+     *
      * @param string $name
+     *   Name of the template to be saved.
      * @param string $type
+     *   Either 'index' or 'method'.
      * @param string $html
+     *   HTML to be saved to the template.
      * @param bool $update
+     *   True if we are updating, false if we are inserting.
+     *
      * @return string
+     *   Returns the template HTML that was saved.
+     *
      * @throws ParameterException
      */
     public function save($name, $type, $html, $update = false)
@@ -66,9 +84,27 @@ class Template extends APIObject
             $uri = '?type=' . $type . '&name=' . urlencode($name);
             $method = 'post';
         }
+        // Make sure that update 404 errors are not logged by replacing the
+        // logger with a dummy that routes errors to /dev/null.
+        if ($update && !(self::$logger instanceof \Psr\Log\NullLogger)) {
+            $cached_logger = self::$logger;
+            self::$logger = new \Psr\Log\NullLogger();
+            $this->clearSubscribers();
+        }
+
         try {
             $this->$method($uri, $html, 'text/html', 'text/html');
+            // Restore logger if it was cached.
+            if (isset($cached_logger)) {
+                self::$logger = $cached_logger;
+                $this->restoreSubscribers();
+            }
         } catch (ResponseException $e) {
+            // Restore logger if it was cached.
+            if (isset($cached_logger)) {
+                self::$logger = $cached_logger;
+                $this->restoreSubscribers();
+            }
             // If update failed, try insert.
             if ($update && $e->getCode() == 404) {
                 $this->save($name, $type, $html, false);


### PR DESCRIPTION
We were already doing this, but now we turn off all loggers when attempting to PUT a template.
