### PR TITLE
DEVSOL-1425: Add security attribute to Method

### DIFF
--- a/Apigee/SmartDocs/Method.php
+++ b/Apigee/SmartDocs/Method.php
@@ -23,8 +23,6 @@ class Method extends APIObject
     protected $name;
     /** @var string */
     protected $verb;
-    /** @var array */
-    protected $authSchemes;
     /**
      * @var array
      *      May contain the following keys:
@@ -83,6 +81,14 @@ class Method extends APIObject
     /** @var string */
     protected $apiId;
 
+    /**
+     * @var array
+     *      This is an array of string identifiers, corresponding to security
+     *      schemes defined by the Security object attached to this model's
+     *      revision.
+     */
+    private $security;
+
     /** @var array */
     protected $metadata;
 
@@ -94,7 +100,6 @@ class Method extends APIObject
         $this->id = '';
         $this->name = '';
         $this->verb = '';
-        $this->authSchemes = array();
         $this->body = array();
         $this->response = array();
         $this->samples = array();
@@ -105,6 +110,7 @@ class Method extends APIObject
         $this->customAttributes = array();
         $this->tags = array();
         $this->metadata = array();
+        $this->security = array();
 
         $this->createdTime = 0;
         $this->modifiedTime = 0;
@@ -146,14 +152,13 @@ class Method extends APIObject
         $this->verb = $verb;
     }
 
-    public function getAuthSchemes()
+    public function getSecurity()
     {
-        return $this->authSchemes;
+        return $this->security;
     }
-
-    public function setAuthSchemes(array $schemes)
+    public function setSecurity(array $security)
     {
-        $this->authSchemes = $schemes;
+        $this->security = $security;
     }
 
     public function getBody()
@@ -346,11 +351,11 @@ class Method extends APIObject
      *
      * @return array
      */
-    public function toArray($verbose = TRUE)
+    public function toArray($verbose = true)
     {
 
         $payload_keys = array(
-            'name', 'verb', 'authSchemes', 'body', 'response', 'samples',
+            'name', 'verb', 'security', 'body', 'response', 'samples',
             'displayName', 'description', 'parameters', 'parameterGroups',
             'customAttributes', 'tags', 'path'
         );
@@ -426,11 +431,11 @@ class Method extends APIObject
      *
      * @param bool $update
      */
-    public function save($update = FALSE)
+    public function save($update = false)
     {
-        $array_members = array('authSchemes', 'parameters', 'parameterGroups', 'tags', 'samples');
+        $array_members = array('security', 'parameters', 'parameterGroups', 'tags', 'samples');
         $object_members = array('body', 'response', 'customAttributes');
-        $payload = $this->toArray(FALSE);
+        $payload = $this->toArray(false);
         foreach ($array_members as $key) {
             if (empty($payload[$key])) {
                 $payload[$key] = array();

--- a/Apigee/SmartDocs/Model.php
+++ b/Apigee/SmartDocs/Model.php
@@ -44,14 +44,6 @@ class Model extends APIObject
 
     /**
      * @var array
-     *      This is an array of string identifiers, corresponding to security
-     *      schemes defined by the Security object attached to this model's
-     *      revision.
-     */
-    private $security;
-
-    /**
-     * @var array
      *      This is a key-value store for any metadata that a client might
      *      want to persist related to the model. It is neither transmitted to
      *      Edge nor pulled from it.
@@ -75,7 +67,6 @@ class Model extends APIObject
         $this->description = '';
         $this->tags = array();
         $this->customAttributes = array();
-        $this->security = array();
         $this->metadata = array();
 
         $this->createdTime = 0;
@@ -151,15 +142,6 @@ class Model extends APIObject
     public function setTags(array $tags)
     {
         $this->tags = $tags;
-    }
-
-    public function getSecurity()
-    {
-        return $this->security;
-    }
-    public function setSecurity(array $security)
-    {
-        $this->security = $security;
     }
 
     public function getCustomAttribute($name)
@@ -240,7 +222,7 @@ class Model extends APIObject
      *
      * @return array
      */
-    public function toArray($verbose = TRUE)
+    public function toArray($verbose = true)
     {
         $payload_keys = array('name', 'displayName', 'description', 'tags', 'customAttributes');
         if ($verbose) {
@@ -312,7 +294,7 @@ class Model extends APIObject
      *
      * @param bool $update
      */
-    public function save($update = FALSE)
+    public function save($update = false)
     {
         $payload = $this->toArray();
         if (empty($payload['customAttributes'])) {

--- a/Apigee/SmartDocs/Model.php
+++ b/Apigee/SmartDocs/Model.php
@@ -44,6 +44,14 @@ class Model extends APIObject
 
     /**
      * @var array
+     *      This is an array of string identifiers, corresponding to security
+     *      schemes defined by the Security object attached to this model's
+     *      revision.
+     */
+    private $security;
+
+    /**
+     * @var array
      *      This is a key-value store for any metadata that a client might
      *      want to persist related to the model. It is neither transmitted to
      *      Edge nor pulled from it.
@@ -67,6 +75,7 @@ class Model extends APIObject
         $this->description = '';
         $this->tags = array();
         $this->customAttributes = array();
+        $this->security = array();
         $this->metadata = array();
 
         $this->createdTime = 0;
@@ -142,6 +151,15 @@ class Model extends APIObject
     public function setTags(array $tags)
     {
         $this->tags = $tags;
+    }
+
+    public function getSecurity()
+    {
+        return $this->security;
+    }
+    public function setSecurity(array $security)
+    {
+        $this->security = $security;
     }
 
     public function getCustomAttribute($name)

--- a/Apigee/SmartDocs/Security/ApiKeyScheme.php
+++ b/Apigee/SmartDocs/Security/ApiKeyScheme.php
@@ -61,8 +61,11 @@ class ApiKeyScheme extends SecurityScheme
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function getType($humanReadable = false)
     {
+        if ($humanReadable) {
+            return 'Api Key';
+        }
         return 'APIKEY';
     }
 

--- a/Apigee/SmartDocs/Security/ApiKeyScheme.php
+++ b/Apigee/SmartDocs/Security/ApiKeyScheme.php
@@ -64,7 +64,7 @@ class ApiKeyScheme extends SecurityScheme
     public function getType($humanReadable = false)
     {
         if ($humanReadable) {
-            return 'Api Key';
+            return 'API Key';
         }
         return 'APIKEY';
     }

--- a/Apigee/SmartDocs/Security/BasicScheme.php
+++ b/Apigee/SmartDocs/Security/BasicScheme.php
@@ -12,8 +12,11 @@ class BasicScheme extends SecurityScheme
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function getType($humanReadable = false)
     {
+        if ($humanReadable) {
+            return 'Basic';
+        }
         return 'BASIC';
     }
 }

--- a/Apigee/SmartDocs/Security/Oauth2Scheme.php
+++ b/Apigee/SmartDocs/Security/Oauth2Scheme.php
@@ -187,8 +187,11 @@ class Oauth2Scheme extends SecurityScheme {
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function getType($humanReadable = false)
     {
+        if ($humanReadable) {
+            return 'OAuth2: ' . ucwords(strtolower($this->getGrantType()));
+        }
         return 'OAUTH2';
     }
 

--- a/Apigee/SmartDocs/Security/SecurityScheme.php
+++ b/Apigee/SmartDocs/Security/SecurityScheme.php
@@ -39,7 +39,7 @@ abstract class SecurityScheme
      *
      * @return string
      */
-    public abstract function getType();
+    public abstract function getType($humanReadable = false);
 
     /**
      * Populates this security scheme from a JSON payload.


### PR DESCRIPTION
- Remove 'authSchemes' from Method object, and replace it with 'security'.
- Persist security to Method object on save, and load it properly on load.
- Give boolean (default false) option on getType() of Security schemes to return a human-readable type name.
