### PR TITLE
MGMT-2188: Model customAttributes can't have empty keys/values

### DIFF
--- a/Apigee/SmartDocs/Model.php
+++ b/Apigee/SmartDocs/Model.php
@@ -176,15 +176,23 @@ class Model extends APIObject
                 unset($this->customAttributes[$name]);
             }
         }
-        elseif ($name !== NULL && $name !== '') {
+        elseif ($name !== NULL && $name !== '' && is_scalar($value)) {
             $this->customAttributes[strval($name)] = strval($value);
+        }
+        else {
+            if (!is_scalar($value)) {
+                throw new ParameterException('Custom Attribute value must be a scalar.');
+            }
+            else {
+                throw new ParameterException('Custom Attribute name cannot be empty.');
+            }
         }
     }
     public function setCustomAttributes(array $attr)
     {
         $this->customAttributes = array();
         foreach ($attr as $key => $value) {
-            if ($value !== NULL && $value !== '' && $key !== NULL && $key !== '') {
+            if ($value !== NULL && $value !== '' && $key !== NULL && $key !== '' && is_scalar($value)) {
                 $this->customAttributes[strval($key)] = strval($value);
             }
         }

--- a/Apigee/SmartDocs/Model.php
+++ b/Apigee/SmartDocs/Model.php
@@ -171,18 +171,23 @@ class Model extends APIObject
     }
     public function setCustomAttribute($name, $value)
     {
-        if (empty($value)) {
+        if ($value === NULL || $value === '') {
             if (array_key_exists($name, $this->customAttributes)) {
                 unset($this->customAttributes[$name]);
             }
         }
-        else {
-            $this->customAttributes[$name] = $value;
+        elseif ($name !== NULL && $name !== '') {
+            $this->customAttributes[strval($name)] = strval($value);
         }
     }
     public function setCustomAttributes(array $attr)
     {
-        $this->customAttributes = $attr;
+        $this->customAttributes = array();
+        foreach ($attr as $key => $value) {
+            if ($value !== NULL && $value !== '' && $key !== NULL && $key !== '') {
+                $this->customAttributes[strval($key)] = strval($value);
+            }
+        }
     }
     public function clearCustomAttribute($name)
     {
@@ -315,6 +320,12 @@ class Model extends APIObject
     public function save($update = false)
     {
         $payload = $this->toArray();
+        // Eliminate any customAttributes with empty keys or values.
+        foreach ($payload['customAttributes'] as $key => $value) {
+            if ($value === NULL || $value === '' || $key === NULL || $key === '') {
+                unset($payload['customAttributes'][$key]);
+            }
+        }
         if (empty($payload['customAttributes'])) {
             $payload['customAttributes'] = new \stdClass;
         }


### PR DESCRIPTION
Ensure the following for customAttributes:
- Keys and values cannot be NULL or the empty string
- Keys and values must be coerced as strings.
- Any such empty customAttributes that might pre-exist must be stripped before saving a Method.
