### PR TITLE
DEVSOL-1554: Invalid date comparison in DeveloperRatePlan.php

### DIFF
--- a/Apigee/Mint/DeveloperRatePlan.php
+++ b/Apigee/Mint/DeveloperRatePlan.php
@@ -358,10 +358,11 @@ class DeveloperRatePlan extends Base\BaseObject
     }
 
     public function isCancelable() {
-        $start_date = $this->getStartDate();
         $org_timezone = new DateTimeZone($this->getRatePlan()->getOrganization()->getTimezone());
+        $start_date = new DateTime($this->getStartDate(), $org_timezone);
         $today = new DateTime('today', $org_timezone);
-        if ($start_date > $today) {
+
+        if ($start_date->getTimestamp() > $today->getTimestamp()) {
             return TRUE;
         }
         return FALSE;


### PR DESCRIPTION
This fixes a date comparison being made between a DateTime object and a date string.
