### PR TITLE
DEVSOL-1812: Do not set invalid country codes

### DIFF
--- a/Apigee/Mint/DataStructures/Address.php
+++ b/Apigee/Mint/DataStructures/Address.php
@@ -3,6 +3,7 @@
 namespace Apigee\Mint\DataStructures;
 
 use \Apigee\Mint\Types\Country;
+use \Apigee\Util\APIObject;
 
 class Address extends DataStructure
 {
@@ -59,8 +60,12 @@ class Address extends DataStructure
 
     public function setCountry($country)
     {
-        Country::validateCountryCode($country);
-        $this->country = $country;
+        // Only set country if it is valid.
+        if(Country::validateCountryCode($country)) {
+            $this->country = $country;
+        } else {
+            APIObject::$logger->error('Invalid country code "' . $country . '" passed from Edge MGMT API.');
+        }
     }
 
     public function getCountry()

--- a/Apigee/Mint/DataStructures/Address.php
+++ b/Apigee/Mint/DataStructures/Address.php
@@ -61,7 +61,7 @@ class Address extends DataStructure
     public function setCountry($country)
     {
         // Only set country if it is valid.
-        if(Country::validateCountryCode($country)) {
+        if (Country::validateCountryCode($country)) {
             $this->country = $country;
         } else {
             APIObject::$logger->error('Invalid country code "' . $country . '" passed from Edge MGMT API.');

--- a/Apigee/Mint/Organization.php
+++ b/Apigee/Mint/Organization.php
@@ -499,7 +499,7 @@ class Organization extends Base\BaseObject
     public function setCountry($country)
     {
         // Only set country if it is valid.
-        if(Country::validateCountryCode($country)) {
+        if (Country::validateCountryCode($country)) {
             $this->country = $country;
         } else {
             APIObject::$logger->error('Invalid country code "' . $country . '" passed from Edge MGMT API.');

--- a/Apigee/Mint/Organization.php
+++ b/Apigee/Mint/Organization.php
@@ -1,9 +1,9 @@
 <?php
 namespace Apigee\Mint;
 
+use \Apigee\Util\APIObject;
 use Apigee\Util\CacheFactory;
 use Apigee\Exceptions\ResponseException;
-use Apigee\Mint\DataStructures\BillingMonth;
 use Apigee\Mint\Types\StatusType;
 use Apigee\Mint\Types\TaxModelType;
 use Apigee\Mint\Types\OrgType;
@@ -498,8 +498,12 @@ class Organization extends Base\BaseObject
 
     public function setCountry($country)
     {
-        Country::validateCountryCode($country);
-        $this->country = $country;
+        // Only set country if it is valid.
+        if(Country::validateCountryCode($country)) {
+            $this->country = $country;
+        } else {
+            APIObject::$logger->error('Invalid country code "' . $country . '" passed from Edge MGMT API.');
+        }
     }
 
     public function getCurrency()

--- a/Apigee/Mint/Types/Country.php
+++ b/Apigee/Mint/Types/Country.php
@@ -302,7 +302,7 @@ final class Country
     public static function validateCountryCode($iso_code)
     {
         if (!array_key_exists($iso_code, self::$iso_codes)) {
-          return FALSE;
+            return FALSE;
         }
         return TRUE;
     }

--- a/Apigee/Mint/Types/Country.php
+++ b/Apigee/Mint/Types/Country.php
@@ -293,11 +293,18 @@ final class Country
         throw new ParameterException('Nonexistent country ‘' . $country_name . '’');
     }
 
+    /**
+     * Validate country code.
+     *
+     * @param $iso_code The two digit country code.
+     * @return bool True if country code is valid, false if not.
+     */
     public static function validateCountryCode($iso_code)
     {
         if (!array_key_exists($iso_code, self::$iso_codes)) {
-            throw new ParameterException('Nonexistent country ISO code ‘' . $iso_code . '’');
+          return FALSE;
         }
+        return TRUE;
     }
 
     // TODO


### PR DESCRIPTION
Instead of throwing an error if a country code is invalid from the backend and not being able to recover, just don't set the country code.
