### PR TITLE
DEVSOL-2055: Properly log Edge calls in debug mode

### DIFF
--- a/Apigee/Util/APIObject.php
+++ b/Apigee/Util/APIObject.php
@@ -10,6 +10,7 @@ use Guzzle\Http\Exception\BadResponseException;
 use Guzzle\Http\Exception\CurlException;
 use Guzzle\Http\Message\EntityEnclosingRequestInterface;
 use Guzzle\Http\EntityBodyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Base class for API object classes. Handles some of the OrgConfig


### PR DESCRIPTION
Missing `use` declaration caused an `if` clause to always evaluate to `FALSE`.
