### PR TITLE
Fix APIProduct class's delete() method

### DIFF
--- a/Apigee/ManagementAPI/APIProduct.php
+++ b/Apigee/ManagementAPI/APIProduct.php
@@ -214,7 +214,7 @@ class APIProduct extends Base
     public function delete($name = null)
     {
         $name = $name ? : $this->name;
-        $this->delete(rawurlencode($name));
+        $this->httpDelete(rawurlencode($name));
         if ($name == $this->name) {
             $this->blankValues();
         }


### PR DESCRIPTION
delete() method of APIProduct class calls itself rather than it would call httpDelete() method and because of that `$product->delete()` isn't working and calling this method leads to an infinite loop.
