### PR TITLE
DEVSOL-2322: Allow clearing of bearer-token cache

### DIFF
--- a/Apigee/Util/CredentialStorageInterface.php
+++ b/Apigee/Util/CredentialStorageInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Apigee\Util;
+
+/**
+ * An interface describing how bearer-tokens and other credentials will be locally stored/cached.
+ * @package Apigee\Util
+ */
+interface CredentialStorageInterface {
+
+    /**
+     * Writes a token or credential to a persistent datastore.
+     *
+     * @param string $identifier
+     * @param string $credential_data
+     */
+    public function write($identifier, $credential_data);
+
+    /**
+     * Clears the persistent datastore.
+     */
+    public function clear();
+
+    /**
+     * Reads a token from the persistent datastore. If it is not found, returns NULL.
+     *
+     * @param string $identifier
+     * @return string|null
+     */
+    public function read($identifier);
+}

--- a/Apigee/Util/FilesystemCredentialStorage.php
+++ b/Apigee/Util/FilesystemCredentialStorage.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Apigee\Util;
+
+/**
+ * Reads/writes bearer-tokens and other credentials from the local filesystem.
+ * @package Apigee\Util
+ */
+class FilesystemCredentialStorage implements CredentialStorageInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function write($identifier, $credential_data)
+    {
+        $dir = self::getTokenCacheDir();
+        file_put_contents("$dir/$identifier", $credential_data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $cache_dir = self::getTokenCacheDir();
+        if ($dh = opendir($cache_dir)) {
+            while (($file = readdir($dh)) !== false) {
+                if (is_file($file) && substr($file, 0, 1) != '.') {
+                    @unlink($file);
+                }
+            }
+            closedir($dh);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($identifier)
+    {
+        $dir = self::getTokenCacheDir();
+        if (!file_exists("$dir/$identifier")) {
+            return false;
+        }
+        return file_get_contents("$dir/$identifier");
+    }
+
+    /**
+     * Returns the temp dir where access tokens are cached.
+     *
+     * @return string
+     */
+    private static function getTokenCacheDir()
+    {
+        return sys_get_temp_dir() . '/edge-access-tokens';
+    }
+}


### PR DESCRIPTION
This commit also returns HTTP status codes as the exception code for `SamlResponseException`s, which allows us to show more helpful error messages to the end-user.