### PR TITLE
MintAPIException exception factory: original exception should be thrown again

### DIFF
--- a/Apigee/Mint/Exceptions/MintApiException.php
+++ b/Apigee/Mint/Exceptions/MintApiException.php
@@ -67,7 +67,9 @@ class MintApiException extends \Exception
      *
      * @param ResponseException $re The response exception from the Edge API
      *
-     * @return MintApiException MintApiException or a subclass of MintApiException
+     * @return MintApiException|ResponseException MintApiException or a
+     * subclass of MintApiException or the original ResponseException if
+     * problem seems to be unrelated to Monetization API.
      */
     public static function factory(ResponseException $re)
     {
@@ -75,9 +77,8 @@ class MintApiException extends \Exception
             return new InsufficientFundsException($re);
         } elseif (MintApiException::isMintExceptionCode($re)) {
             return new MintApiException($re);
-        } else {
-            throw new ParameterException('Not a registered mint exception.', $re->getCode(), $re);
         }
+        return $re;
     }
 
     /**


### PR DESCRIPTION
Right now, if an exception can not be identified as a MintAPIException, factory method re-thrown it as a ParameterException. There is two problem with the current solution.
a) Wrong parameter order, the 2nd parameter of the ParamerException's constructor should be a status code and only 3rd one the original exception object.
b) The real reason of the exception can not be caught properly because by wrapping the original Response exception to a Parameter exception makes it unnecessarily complicated. (The message of the Parameter exception is also not too meaningful.)