### PR TITLE
Unify how data structure objects converted to strings (transformed to json.)

### DIFF
--- a/Apigee/Mint/DataStructures/Address.php
+++ b/Apigee/Mint/DataStructures/Address.php
@@ -23,11 +23,6 @@ class Address extends DataStructure
         }
     }
 
-    public function __toString()
-    {
-        return json_encode($this);
-    }
-
     public function setAddress1($address1)
     {
         $this->address1 = $address1;
@@ -66,8 +61,7 @@ class Address extends DataStructure
         } elseif ($country_code == 'UK') {
             // Change incorrect United Kingdom 'UK' country code to 'GB'.
             $this->country = 'GB';
-        }
-        else {
+        } else {
             APIObject::$logger->error('Invalid country code "' . $country_code . '" passed from Edge MGMT API.');
         }
     }

--- a/Apigee/Mint/DataStructures/RatePlanDetail.php
+++ b/Apigee/Mint/DataStructures/RatePlanDetail.php
@@ -138,22 +138,6 @@ class RatePlanDetail extends DataStructure
         }
     }
 
-    public function __toString()
-    {
-        $obj = array();
-        $properties = array_keys(get_object_vars($this));
-        foreach ($properties as $property) {
-            if (isset($this->$property)) {
-                if (is_object($this->$property)) {
-                    $obj[$property] = json_decode((string)$this->$property, true);
-                } else {
-                    $obj[$property] = $this->$property;
-                }
-            }
-        }
-        return json_encode($obj);
-    }
-
     /**
      * @return \Apigee\Mint\Organization
      */

--- a/Apigee/Mint/DataStructures/RatePlanRate.php
+++ b/Apigee/Mint/DataStructures/RatePlanRate.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Apigee\Mint\DataStructures;
 
 class RatePlanRate extends DataStructure
@@ -54,22 +55,6 @@ class RatePlanRate extends DataStructure
                 }
             }
         }
-    }
-
-    public function __toString()
-    {
-        $obj = array();
-        $properties = array_keys(get_object_vars($this));
-        foreach ($properties as $property) {
-            if (isset($this->$property)) {
-                if (is_object($this->$property)) {
-                    $obj[$property] = json_decode((string)$this->$property, true);
-                } else {
-                    $obj[$property] = $this->$property;
-                }
-            }
-        }
-        return json_encode($obj);
     }
 
     /**

--- a/Apigee/Mint/DataStructures/SupportedCurrency.php
+++ b/Apigee/Mint/DataStructures/SupportedCurrency.php
@@ -236,6 +236,9 @@ class SupportedCurrency extends DataStructure
 
     public function __toString()
     {
-        return json_encode($this);
+        $json = parent::__toString();
+        $obj = json_decode($json, true);
+        $obj['organization'] = array('id' => $this->organization->getId());
+        return json_encode($obj);
     }
 }


### PR DESCRIPTION
__toString() method should be defined in the parent DataStructures class, therefore all subclass would inherit it and override it if necessary. (Like SupportedCurrency)