### PR TITLE
DEVSOL-2400 : Make sure that the removeDeveloper is wrapped around a …

### DIFF
--- a/Apigee/ManagementAPI/Company.php
+++ b/Apigee/ManagementAPI/Company.php
@@ -374,7 +374,7 @@ class Company extends Base
         // in DEVSOL-2400.
         try {
             $this->removeDeveloper($dev_email, $company_name);
-        }catch(\Exception $e){
+        } catch(\Exception $e) {
             //Ignore the delete since we ideally want to update.
         }
 

--- a/Apigee/ManagementAPI/Company.php
+++ b/Apigee/ManagementAPI/Company.php
@@ -372,7 +372,11 @@ class Company extends Base
         // This is a workaround for the issue described in CORESERV-849, and will
         // prevent multiple roles from being created, resolving the issue described
         // in DEVSOL-2400.
-        $this->removeDeveloper($dev_email, $company_name);
+        try {
+            $this->removeDeveloper($dev_email, $company_name);
+        }catch(\Exception $e){
+            //Ignore the delete since we ideally want to update.
+        }
 
         $payload = array('developer' => array(
             array(


### PR DESCRIPTION
Make sure that the removeDeveloper is wrapped around a try catch loop. 

When the company is created for the first time the Developer does not exist in the company and the call fails.