### PR TITLE
\Apigee\ManagementAPI\DeveloperApp::loadByAppId() should not return a CompanyApp

### DIFF
--- a/Apigee/ManagementAPI/DeveloperApp.php
+++ b/Apigee/ManagementAPI/DeveloperApp.php
@@ -212,15 +212,13 @@ class DeveloperApp extends AbstractApp
         $response = $this->responseObj;
         if (array_key_exists('developerId', $response)) {
             $ownerId = $this->getDeveloperMailById($response['developerId']);
-            $obj =& $this;
             $resetEligible = true;
         } else {
             $ownerId = $response['companyName'];
-            $obj = new CompanyApp($this->getConfig(), $ownerId);
             $resetEligible = false;
         }
 
-        self::loadFromResponse($obj, $response, $ownerId);
+        self::loadFromResponse($this, $response, $ownerId);
         // Must load developer to get email
         if ($resetDeveloper && $resetEligible) {
             $resetBaseUrl = '/o/'
@@ -230,7 +228,7 @@ class DeveloperApp extends AbstractApp
                 . '/apps';
             $this->setBaseUrl($resetBaseUrl);
         }
-        return $obj;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Besides this is a bad practice it also brakes \Apigee\ManagementAPI\AbstractApp::loadFromResponse() call if an app is a company app. In that case, this method is unable to fill in its first argument's properties from the API response. This is the reason why you had to grab the returned value of the loadByAppId() in the \ApigeeCompanyAppController::delete() in the Apigee Developer Portal's code base, because $dev_app0's properties remain empty.

After applying this fix you'll probably fix some calls on the portal where you have relied on this bad implementation. For example in this delete() call I'd check whether the app is a company app if it is, I'd delete it as a company app, otherwise as a simple developer app.

