### PR TITLE
DEVSOL-2625: Company role issue

### DIFF
--- a/Apigee/ManagementAPI/Company.php
+++ b/Apigee/ManagementAPI/Company.php
@@ -520,7 +520,7 @@ class Company extends Base
             $url = rawurlencode($companyName) . '/developers';
             $this->get($url);
             if (is_array($this->responseObj) && array_key_exists('developer', $this->responseObj)) {
-                $developers = $this->responseObj['developers'];
+                $developers = $this->responseObj['developer'];
             } else {
                 $developers = array();
             }


### PR DESCRIPTION
MINT roles are getting dropped after switching company. Due to this error, the roles of the developers are not retrieved from MINT and hence, when they switch the companies, their MINT Roles get lost.