### PR TITLE
b/65101827 SF 1430625 - Analytics for Company APPs not working

### DIFF
--- a/Apigee/ManagementAPI/DeveloperAppAnalytics.php
+++ b/Apigee/ManagementAPI/DeveloperAppAnalytics.php
@@ -154,11 +154,7 @@ class DeveloperAppAnalytics extends Base
     public function getByAppName($devId, $appName, $metric, $tStart, $tEnd, $tUnit, $sortBy, $sortOrder = 'ASC')
     {
         $params = self::validateParameters($metric, $tStart, $tEnd, $tUnit, $sortBy, $sortOrder);
-
-        if (!empty($devId)) {
-            $org = $this->config->orgName;
-            $params['filter'] = "(developer eq '$org@@@$devId')";
-        }
+      
         $params['developer_app'] = $appName;
 
         $url = 'apps?';


### PR DESCRIPTION
Company app analytics was not working properly because the call to analytics was filtering by developer. Removed filter from DeveloperAppAnalytics.getByAppName that was filtering by developer.