### PR TITLE
Incorrect usage of self and static

### DIFF
--- a/Apigee/ManagementAPI/AbstractApp.php
+++ b/Apigee/ManagementAPI/AbstractApp.php
@@ -1113,7 +1113,7 @@ abstract class AbstractApp extends Base
         }
 
         // Let subclasses fiddle with the payload here
-        self::preSave($payload, $this);
+        static::preSave($payload, $this);
 
         $this->post($url, $payload);
         $response = $this->responseObj;


### PR DESCRIPTION
Probably multiple places, but this was the one that I had run into when I was working on #87. Based on the comment above this line should call a subclass' `preSave()` method (ex.: DeveloperApp), but it actually calls AbstractApp's `preSave()` method, always.