### PR TITLE
Incorrect post url in api calls

### DIFF
--- a/Apigee/Mint/Developer.php
+++ b/Apigee/Mint/Developer.php
@@ -418,19 +418,13 @@ class Developer extends Base\BaseObject
 
     public function getRevenueReport($report)
     {
-        $url = '/mint/organizations/'
-            . rawurlencode($this->config->orgName)
-            . '/developers/'
-            . rawurlencode($this->email)
-            . '/revenue-reports';
-        $content_type = 'application/json; charset=utf-8';
-        $accept_type = 'application/octet-stream; charset=utf-8';
+      $url = rawurlencode($this->email) . '/revenue-reports';
+      $content_type = 'application/json; charset=utf-8';
+      $accept_type = 'application/octet-stream; charset=utf-8';
 
-        $this->setBaseUrl($url);
-        $this->post(null, $report, $content_type, $accept_type);
-        $this->restoreBaseUrl();
-        $response = $this->responseText;
-        return $response;
+      $this->post($url, $report, $content_type, $accept_type);
+      $response = $this->responseText;
+      return $response;
     }
 
     public function saveReportDefinition($report_def)

--- a/Apigee/Mint/Organization.php
+++ b/Apigee/Mint/Organization.php
@@ -699,13 +699,11 @@ class Organization extends Base\BaseObject
                 'billingYear' => $year
             );
 
-            $url = '/mint/organizations/' . rawurlencode($this->config->orgName) . '/prepaid-balance-reports';
-            $content_type = 'application/json; charset=utf-8';
-            $accept_type = 'application/octet-stream; charset=utf-8';
-            $this->setBaseUrl($url);
-            $this->post(null, $data, $content_type, $accept_type);
-            $this->restoreBaseUrl();
-            $response = $this->responseText;
+          $url = rawurlencode($this->config->orgName) . '/prepaid-balance-reports';
+          $content_type = 'application/json; charset=utf-8';
+          $accept_type = 'application/octet-stream; charset=utf-8';
+          $this->post($url, $data, $content_type, $accept_type);
+          $response = $this->responseText;
         } catch (ResponseException $re) {
             if (MintApiException::isMintExceptionCode($re)) {
                 throw new MintApiException($re);


### PR DESCRIPTION
in Developer::getRevenueReport() 
and Organization::getPrepaidBalanceReport()
Setting always base Url caused problems with incorrect url. The required subpath should be passed to first argument of post() method.