### PR TITLE
Developer.getRatePlanByProduct() fix

### DIFF
--- a/Apigee/Mint/Developer.php
+++ b/Apigee/Mint/Developer.php
@@ -489,11 +489,19 @@ class Developer extends Base\BaseObject
             }
         }
         try {
+            // The /{developer}/products/{product_id}/rate-plan-by-developer-product/
+            // resource is under /developer, so we do a GET call to get RatePlan
+            // object.
             $url = rawurlencode($developer_id)
                 . '/products/'
                 . rawurlencode($product_id)
                 . '/rate-plan-by-developer-product/';
             $this->get($url);
+
+            // We do not need to make any calls to RatePlan resources, so we
+            // pass in a null m_package_id parameter, then use loadFromRawData
+            // to create a RatePlan object from the returned response from
+            // rate-plan-by-developer-product call above.
             $ratePlan = new RatePlan(null, $this->config);
             $ratePlan->loadFromRawData($this->responseObj);
         } catch (\Exception $e) {

--- a/Apigee/Mint/RatePlan.php
+++ b/Apigee/Mint/RatePlan.php
@@ -228,6 +228,12 @@ class RatePlan extends Base\BaseObject
      * Class constructor
      * @param string $m_package_id Monetization Package id
      * @param \Apigee\Util\OrgConfig $config
+     *
+     * NOTE: This constructor is used by Developer.getRatePlanByProduct()
+     * in order to use the loadFromRawData() method, since there is a
+     * resource under /developer that returns back RatePlan JSON.  Since that
+     * method is only using this object to covert JSON into a RatePlan object,
+     * the m_package_id parameter passed in is NULL.
      */
     public function __construct($m_package_id, OrgConfig $config)
     {
@@ -248,6 +254,14 @@ class RatePlan extends Base\BaseObject
         $package = new MonetizationPackage($config);
         $package->load($m_package_id);
         $this->monetizationPackage = $package;
+
+        // If the package id is passed in, load it. If not, do not
+        // make any calls to the API during construction.
+        if(isset($m_package_id) and ($m_package_id != '')) {
+          $package->load($m_package_id);
+          $this->monetizationPackage = $package;
+        }
+
         // Load the default supported currency of this organisation.
         foreach ($org->listSupportedCurrencies() as $currency) {
             /** @var SupportedCurrency $currency */


### PR DESCRIPTION
The Mint Developer object needs to make a call to get rate plans that are valid for a given developer and product (Developer.getRatePlanByProduct()).  The Developer object makes the call to a /developer resource to get the RatePlan data, then passes the response to the RatePlan class to make a RatePlan object.  Due to this, the RatePlan constructor should not make any API call since we are only using the RatePlan class’ loadFromRawData() method to construct a valid object.