### PR TITLE
blankValues() should not clear passed company

### DIFF
--- a/Apigee/ManagementAPI/CompanyApp.php
+++ b/Apigee/ManagementAPI/CompanyApp.php
@@ -35,6 +35,7 @@ class CompanyApp extends AbstractApp
      */
     public function __construct(OrgConfig $config, $company)
     {
+        $this->blankValues();
         $this->ownerIdentifierField = 'companyName';
         if ($company instanceof Company) {
             $this->companyName = $company->getName();
@@ -44,7 +45,6 @@ class CompanyApp extends AbstractApp
         }
         $baseUrl = '/o/' . rawurlencode($config->orgName) . '/companies/' . $this->companyName . '/apps';
         $this->init($config, $baseUrl);
-        $this->blankValues();
     }
 
     /**


### PR DESCRIPTION
blankValues() values should be called earlier than company property is set from constructor parameter otherwise it removes the value.