### PR TITLE
Update library for PHP 7.2

### DIFF
--- a/Apigee/ManagementAPI/AbstractApp.php
+++ b/Apigee/ManagementAPI/AbstractApp.php
@@ -833,7 +833,7 @@ abstract class AbstractApp extends Base
     protected static function loadCredentials(AbstractApp &$obj, array $credentials)
     {
         // Find the credential with the max issuedAt attribute which isn't expired.
-        if (count($credentials) > 0) {
+        if (!empty($credentials)) {
             $credential = null;
             // Sort credentials by issuedAt descending.
             usort($credentials, array(__CLASS__, 'sortCredentials'));
@@ -900,7 +900,7 @@ abstract class AbstractApp extends Base
             }
 
             // Some apps may be misconfigured and need to be populated with their apiproducts based on credential.
-            if (count($obj->apiProducts) == 0) {
+            if (empty($obj->apiProducts)) {
                 $obj->apiProducts = array();
                 foreach ($obj->credentialApiProducts as $product) {
                     $obj->apiProducts[] = $product['apiproduct'];
@@ -1101,7 +1101,7 @@ abstract class AbstractApp extends Base
                 $this->httpDelete($delete_uri);
             }
             // api-product additions can happen in a batch.
-            if (count($diff->to_add) > 0) {
+            if (!empty($diff->to_add)) {
                 $this->post($key_uri, array('apiProducts' => $diff->to_add));
             }
         } else {
@@ -1120,7 +1120,7 @@ abstract class AbstractApp extends Base
 
         $credential_response = null;
 
-        if (count($response['credentials']) > 0) {
+        if (!empty($response['credentials'])) {
             $current_credential = null;
             // Find credential -- it should have the maximum issuedAt date.
             $max_issued_at = -1;
@@ -1146,7 +1146,7 @@ abstract class AbstractApp extends Base
             }
 
             // If any credential attributes are present, save them
-            if ($current_credential && count($this->credentialAttributes) > 0) {
+            if ($current_credential && !empty($this->credentialAttributes)) {
                 $payload = $current_credential;
                 $payload['attributes'] = array();
                 foreach ($this->credentialAttributes as $name => $val) {

--- a/Apigee/ManagementAPI/Company.php
+++ b/Apigee/ManagementAPI/Company.php
@@ -281,7 +281,7 @@ class Company extends Base
             'status' => $this->status,
             'attributes' => array()
         );
-        if (count($this->attributes) > 0) {
+        if (!empty($this->attributes)) {
             $payload['attributes'] = array();
             foreach ($this->attributes as $name => $value) {
                 $payload['attributes'][] = array('name' => $name, 'value' => $value);

--- a/Apigee/ManagementAPI/Developer.php
+++ b/Apigee/ManagementAPI/Developer.php
@@ -502,7 +502,7 @@ class Developer extends Base
             'firstName' => $this->firstName,
             'lastName' => $this->lastName,
         );
-        if (count($this->attributes) > 0) {
+        if (!empty($this->attributes)) {
             $payload['attributes'] = array();
             $i = 0;
             foreach ($this->attributes as $name => $value) {

--- a/Apigee/ManagementAPI/DeveloperAppAnalytics.php
+++ b/Apigee/ManagementAPI/DeveloperAppAnalytics.php
@@ -295,7 +295,7 @@ class DeveloperAppAnalytics extends Base
     protected static function validateParameters($metric, $timeStart, $timeEnd, $timeUnit, $sortBy, $sortOrder)
     {
         $metricItems = preg_split('!\s*,\s*!', $metric);
-        if (count($metricItems) == 0) {
+        if (empty($metricItems)) {
             throw new ParameterException('Missing metric.');
         }
         $validMetrics = array_keys(self::getMetrics());
@@ -305,7 +305,7 @@ class DeveloperAppAnalytics extends Base
             }
         }
         $sortByItems = preg_split('!\s*,\s*!', $sortBy);
-        if (count($sortByItems) == 0) {
+        if (empty($sortByItems)) {
             throw new ParameterException('Missing sort-by metric');
         }
         foreach ($sortByItems as $sortByItem) {

--- a/Apigee/Mint/Application.php
+++ b/Apigee/Mint/Application.php
@@ -129,7 +129,7 @@ class Application extends Base\BaseObject
                 self::$logger->notice('No setter method was found for property "' . $property . '"');
             }
         }
-        if (isset($data['product']) && is_array($data['product']) && count($data['product']) > 0) {
+        if (isset($data['product']) && is_array($data['product']) && !empty($data['product'])) {
             foreach ($data['product'] as $product_item) {
                 $product = new Product($this->config);
                 $product->loadFromRawData($product_item);

--- a/Apigee/Mint/BankDetail.php
+++ b/Apigee/Mint/BankDetail.php
@@ -140,7 +140,7 @@ class BankDetail extends Base\BaseObject
             }
         }
 
-        if (isset($data['address']) && is_array($data['address']) && count($data['address']) > 0) {
+        if (isset($data['address']) && is_array($data['address']) && !empty($data['address'])) {
             $this->address = new DataStructures\Address($data['address']);
         }
     }

--- a/Apigee/Mint/Developer.php
+++ b/Apigee/Mint/Developer.php
@@ -173,7 +173,7 @@ class Developer extends Base\BaseObject
             }
         }
         $this->id = $data['id'];
-        if (isset($data['address']) && is_array($data['address']) && count($data['address']) > 0) {
+        if (isset($data['address']) && is_array($data['address']) && !empty($data['address'])) {
             foreach ($data['address'] as $addr_item) {
                 $this->addresses[] = new DataStructures\Address($addr_item);
             }

--- a/Apigee/Mint/DeveloperRatePlan.php
+++ b/Apigee/Mint/DeveloperRatePlan.php
@@ -139,7 +139,7 @@ class DeveloperRatePlan extends Base\BaseObject
             $this->initValues();
         }
 
-        if (isset($data['ratePlan']) && is_array($data['ratePlan']) && count($data['ratePlan']) > 0) {
+        if (isset($data['ratePlan']) && is_array($data['ratePlan']) && !empty($data['ratePlan'])) {
             if (isset($data['ratePlan']['monetizationPackage']['id'])) {
                 $m_package_id = $data['ratePlan']['monetizationPackage']['id'];
                 $this->ratePlan = new RatePlan($m_package_id, $this->config);

--- a/Apigee/SmartDocs/Resource.php
+++ b/Apigee/SmartDocs/Resource.php
@@ -222,7 +222,7 @@ class Resource extends APIObject
         foreach ($payload_keys as $key) {
             $payload[$key] = $this->$key;
         }
-        if ($verbose && count($this->methods) > 0) {
+        if ($verbose && !empty($this->methods)) {
             $payload['methods'] = array();
             foreach ($this->methods as $method) {
                 $payload['methods'][] = $method->toArray();

--- a/Apigee/SmartDocs/Revision.php
+++ b/Apigee/SmartDocs/Revision.php
@@ -266,7 +266,7 @@ class Revision extends APIObject
         foreach ($payload_keys as $key) {
             $payload[$key] = $this->$key;
         }
-        if ($verbose && count($this->resources) > 0) {
+        if ($verbose && !empty($this->resources)) {
             $payload['resources'] = array();
             foreach ($this->resources as $resource) {
                 $payload['resources'][] = $resource->toArray();


### PR DESCRIPTION
In places where count() was being used to test for empty (count($var) == 0) or not empty (count($var) > 0)) they are replaced with empty(). In places where an actual count was needed, the line was no modified.