### PR TITLE
Fixed situations when Exceptions from Edge could leave incorrect base urls

### DIFF
--- a/Apigee/ManagementAPI/DeveloperAppAnalytics.php
+++ b/Apigee/ManagementAPI/DeveloperAppAnalytics.php
@@ -232,8 +232,11 @@ class DeveloperAppAnalytics extends Base
     {
         $env_url = '/o/' . rawurlencode($this->config->orgName) . '/environments';
         $this->setBaseUrl($env_url);
-        $this->get();
-        $this->restoreBaseUrl();
+        try {
+            $this->get();
+        } finally {
+            $this->restoreBaseUrl();
+        }
         return $this->responseObj;
     }
 

--- a/Apigee/Mint/BankDetail.php
+++ b/Apigee/Mint/BankDetail.php
@@ -152,16 +152,22 @@ class BankDetail extends Base\BaseObject
         } else {
             $baseUrl = '/mint/organizations/' . rawurlencode($this->config->orgName) . '/bank-details/' . $this->id;
             $this->setBaseUrl($baseUrl);
-            $this->put(null, $this->__toString());
-            $this->restoreBaseUrl();
+            try {
+              $this->put(null, $this->__toString());
+            } finally {
+              $this->restoreBaseUrl();
+            }
         }
     }
 
     public function delete()
     {
         $this->setBaseUrl('/mint/organizations/' . rawurlencode($this->config->orgName) . '/bank-details/' . $this->id);
-        $this->httpDelete();
-        $this->restoreBaseUrl();
+        try {
+          $this->httpDelete();
+        } finally {
+          $this->restoreBaseUrl();
+        }
     }
 
     public function __toString()

--- a/Apigee/Mint/BillingDocument.php
+++ b/Apigee/Mint/BillingDocument.php
@@ -172,8 +172,11 @@ class BillingDocument extends Base\BaseObject
         $accept_type = 'application/json; charset=utf-8';
 
         $this->setBaseUrl($url);
-        $this->post(null, json_encode($comm_criteria), $content_type, $accept_type, $options);
-        $this->restoreBaseUrl();
+        try {
+          $this->post(null, json_encode($comm_criteria), $content_type, $accept_type, $options);
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $response = $this->responseObj;
         $docs = array();
         foreach ($response[$this->wrapper_tag] as $doc) {
@@ -191,8 +194,11 @@ class BillingDocument extends Base\BaseObject
     {
         $url = '/mint/organizations/' . rawurlencode($this->config->orgName) . '/billing-documents-months';
         $this->setBaseUrl($url);
-        $this->get();
-        $this->restoreBaseUrl();
+        try {
+          $this->get();
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $data = $this->responseObj;
 
         $months = array();
@@ -387,8 +393,11 @@ class BillingDocument extends Base\BaseObject
                 'documentNumber' => $bill_doc_number
             );
             $this->setBaseUrl($url);
-            $this->post(null, $mintCriteria);
-            $this->restoreBaseUrl();
+            try {
+              $this->post(null, $mintCriteria);
+            } finally {
+              $this->restoreBaseUrl();
+            }
             $response = $this->responseObj;
 
             foreach ($response[$this->wrapper_tag] as $doc) {

--- a/Apigee/Mint/Developer.php
+++ b/Apigee/Mint/Developer.php
@@ -418,43 +418,25 @@ class Developer extends Base\BaseObject
 
     public function getRevenueReport($report)
     {
-        $url = '/mint/organizations/'
-            . rawurlencode($this->config->orgName)
-            . '/developers/'
-            . rawurlencode($this->email)
-            . '/revenue-reports';
+        $url = rawurlencode($this->email) . '/revenue-reports';
         $content_type = 'application/json; charset=utf-8';
         $accept_type = 'application/octet-stream; charset=utf-8';
 
-        $this->setBaseUrl($url);
-        $this->post(null, $report, $content_type, $accept_type);
-        $this->restoreBaseUrl();
+        $this->post($url, $report, $content_type, $accept_type);
         $response = $this->responseText;
         return $response;
     }
 
     public function saveReportDefinition($report_def)
     {
-        $url = '/mint/organizations/'
-            . rawurlencode($this->config->orgName)
-            . '/developers/'
-            . rawurlencode($this->email)
-            . '/report-definitions';
-        $this->setBaseUrl($url);
-        $this->post(null, $report_def);
-        $this->restoreBaseUrl();
+        $url = rawurlencode($this->email) . '/report-definitions';
+        $this->post($url, $report_def);
     }
 
     public function getReportDefinitions()
     {
-        $url = '/mint/organizations/'
-            . rawurlencode($this->config->orgName)
-            . '/developers/'
-            . rawurlencode($this->email)
-            . '/report-definitions';
-        $this->setBaseUrl($url);
-        $this->get();
-        $this->restoreBaseUrl();
+        $url = rawurlencode($this->email) . '/report-definitions';
+        $this->get($url);
         $data = $this->responseObj;
         $revenue_reports = array();
         foreach ($data['reportDefinition'] as $report) {

--- a/Apigee/Mint/DeveloperRatePlan.php
+++ b/Apigee/Mint/DeveloperRatePlan.php
@@ -180,8 +180,11 @@ class DeveloperRatePlan extends Base\BaseObject
                 'suppressWarning' => true
             );
             $this->setBaseUrl($url);
-            $this->post(null, $obj);
-            $this->restoreBaseUrl();
+            try {
+              $this->post(null, $obj);
+            } finally {
+              $this->restoreBaseUrl();
+            }
         } catch (ResponseException $re) {
             if (MintApiException::isMintExceptionCode($re)) {
                 throw new MintApiException($re);
@@ -205,15 +208,20 @@ class DeveloperRatePlan extends Base\BaseObject
         );
         try {
             $this->setBaseUrl($url);
-            if ($save_method == 'create') {
+            try {
+              if ($save_method == 'create') {
                 $this->post(null, $obj);
-            } elseif ($save_method == 'update') {
+              }
+              elseif ($save_method == 'update') {
                 $obj['id'] = $this->id;
                 $this->put($this->getId(), $obj);
-            } else {
+              }
+              else {
                 throw new ParameterException('Unsupported save method argument: ' . $save_method);
+              }
+            } finally {
+              $this->restoreBaseUrl();
             }
-            $this->restoreBaseUrl();
         } catch (ResponseException $re) {
             $e = MintApiException::factory($re);
             throw $e;
@@ -229,8 +237,11 @@ class DeveloperRatePlan extends Base\BaseObject
             . '/developer-rateplans/'
             . rawurlencode($this->id);
         $this->setBaseUrl($baseUrl);
-        $this->httpDelete(null);
-        $this->restoreBaseUrl();
+        try {
+          $this->httpDelete(null);
+        } finally {
+          $this->restoreBaseUrl();
+        }
     }
 
     /**

--- a/Apigee/Mint/MonetizationPackage.php
+++ b/Apigee/Mint/MonetizationPackage.php
@@ -242,8 +242,11 @@ class MonetizationPackage extends Base\BaseObject
             . rawurlencode($developer_id)
             . '/monetization-packages';
         $this->setBaseUrl($url);
-        $this->get(null, 'application/json; charset=utf-8', array(), $options);
-        $this->restoreBaseUrl();
+        try {
+          $this->get(null, 'application/json; charset=utf-8', array(), $options);
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $response = $this->responseObj;
 
         $return_objects = array();

--- a/Apigee/Mint/Organization.php
+++ b/Apigee/Mint/Organization.php
@@ -184,8 +184,11 @@ class Organization extends Base\BaseObject
     public function listOrganizationIdentifiers()
     {
         $this->setBaseUrl('/organizations');
-        $this->get();
-        $this->restoreBaseUrl();
+        try {
+          $this->get();
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $list = $this->responseObj;
         return $list;
     }
@@ -699,12 +702,10 @@ class Organization extends Base\BaseObject
                 'billingYear' => $year
             );
 
-            $url = '/mint/organizations/' . rawurlencode($this->config->orgName) . '/prepaid-balance-reports';
+            $url = rawurlencode($this->config->orgName) . '/prepaid-balance-reports';
             $content_type = 'application/json; charset=utf-8';
             $accept_type = 'application/octet-stream; charset=utf-8';
-            $this->setBaseUrl($url);
-            $this->post(null, $data, $content_type, $accept_type);
-            $this->restoreBaseUrl();
+            $this->post($url, $data, $content_type, $accept_type);
             $response = $this->responseText;
         } catch (ResponseException $re) {
             if (MintApiException::isMintExceptionCode($re)) {

--- a/Apigee/Mint/RatePlan.php
+++ b/Apigee/Mint/RatePlan.php
@@ -294,8 +294,11 @@ class RatePlan extends Base\BaseObject
             . rawurlencode($this->developerId)
             . '/rate-plans';
         $this->setBaseUrl($url);
-        $this->get(null, 'application/json; charset=utf-8', array(), $options);
-        $this->restoreBaseUrl();
+        try {
+          $this->get(null, 'application/json; charset=utf-8', array(), $options);
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $response = $this->responseObj;
 
         $return_objects = array();

--- a/Apigee/Mint/ReportDefinition.php
+++ b/Apigee/Mint/ReportDefinition.php
@@ -111,8 +111,11 @@ class ReportDefinition extends BaseObject
             . rawurlencode($id)
             . '/report-definitions';
         $this->setBaseUrl($url);
-        $this->get();
-        $this->restoreBaseUrl();
+        try {
+          $this->get();
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $data = $this->responseObj;
         $revenue_reports = array();
         foreach ($data['reportDefinition'] as $report) {

--- a/Apigee/Mint/TermAndCondition.php
+++ b/Apigee/Mint/TermAndCondition.php
@@ -139,8 +139,11 @@ class TermAndCondition extends Base\BaseObject
                 $url .= '?current=true';
             }
             $this->setBaseUrl($url);
-            $this->get();
-            $this->restoreBaseUrl();
+            try {
+              $this->get();
+            } finally {
+              $this->restoreBaseUrl();
+            }
             $data = $this->responseObj;
             $cache_manager->set('developer_accepted_tncs:' . $developer_id, $data);
         }
@@ -213,8 +216,11 @@ class TermAndCondition extends Base\BaseObject
             . rawurlencode($id)
             . '/developer-tncs';
         $this->setBaseUrl($url);
-        $this->post(null, $tnc->__toString());
-        $this->restoreBaseUrl();
+        try {
+          $this->post(null, $tnc->__toString());
+        } finally {
+          $this->restoreBaseUrl();
+        }
         $tnc = new DeveloperTnc($this->responseObj);
         return $tnc;
     }

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ in the same way as the Apigee Developer Services portal.
 
 The Edge PHP SDK has the following prerequisites:
 
-* PHP 5.3.3 or greater. This is required due to the SDK’s use of PHP namespaces
-  and closures, which were not available in 5.2 or earlier.
+* PHP 7.1 or greater. This is required due to the SDK’s use of PHP namespaces
+  and closures, and finally block.
 * JSON support built into PHP. This is enabled in almost all default builds of
   PHP. Certain Linux distributions (such as Debian) may ship with JSON-C
   instead of the standard JSON, due to licensing restrictions; this is also

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "guzzle/guzzle": ">=3.7",
         "psr/log": "1.*"
     },


### PR DESCRIPTION
In current Edge SDK version any HTTP Exception from Edge could leave incorrect base url for next requests send to Edge (including situations when for example revenue reports were empty for chosen time period).
This patch makes sure that `$this->restoreBaseUrl();` is executed in finally block whenever it might affect base path. There are a few places where it is removed when base path is included in request path.